### PR TITLE
Use non durable queue, with auto-deletion in case of network failure

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,7 +1,6 @@
 {
     "rabbitmq": {
         "exchange-name": "stat_persistor_exchange",
-        "queue-name": "raspberry",
         "broker-url": "amqp://user:password@servername/"
     },
     "logger": {

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -25,10 +25,9 @@ class Daemon(ConsumerMixin):
         self.connection = kombu.Connection(self.config.rabbitmq['broker-url'])
         exchange_name = self.config.rabbitmq['exchange-name']
         exchange = kombu.Exchange(exchange_name, type="direct")
-        queue_name = self.config.rabbitmq['queue-name']
+        queue = kombu.Queue('', exchange=exchange, durable=False, exclusive=True, auto_delete=True)
         logging.getLogger(__name__).info("listen following exchange: {exchange}, queue name: {queue}".
-                                         format(exchange=exchange_name, queue=queue_name))
-        queue = kombu.Queue(queue_name, exchange=exchange, durable=True)
+                                         format(exchange=exchange_name, queue=queue.name))
         self.queues.append(queue)
 
     def get_consumers(self, Consumer, channel):


### PR DESCRIPTION
To avoid filling a useless queue and losing the real-time effect (when getting back online), I propose not to use a durable named-queue.

I HAVEN'T TESTED!! Since I don't have a Raspberry Pi with me :p 
But I'm available if you want to test of course ;)