### PR TITLE
Change exchange type and filter only v1.journeys messages on MQ side

### DIFF
--- a/settings.json
+++ b/settings.json
@@ -1,6 +1,6 @@
 {
     "rabbitmq": {
-        "exchange-name": "stat_persistor_exchange",
+        "exchange-name": "stat_persistor_exchange_topic",
         "broker-url": "amqp://user:password@servername/"
     },
     "logger": {

--- a/src/daemon.py
+++ b/src/daemon.py
@@ -24,8 +24,8 @@ class Daemon(ConsumerMixin):
         """
         self.connection = kombu.Connection(self.config.rabbitmq['broker-url'])
         exchange_name = self.config.rabbitmq['exchange-name']
-        exchange = kombu.Exchange(exchange_name, type="direct")
-        queue = kombu.Queue('', exchange=exchange, durable=False, exclusive=True, auto_delete=True)
+        exchange = kombu.Exchange(exchange_name, type="topic")
+        queue = kombu.Queue('', exchange=exchange, routing_key='v1.journeys', durable=False, exclusive=True, auto_delete=True)
         logging.getLogger(__name__).info("listen following exchange: {exchange}, queue name: {queue}".
                                          format(exchange=exchange_name, queue=queue.name))
         self.queues.append(queue)


### PR DESCRIPTION
We changed the exchange type in Navitia2 in order to be able to filter messages at RabbitMQ level (rather than filter them on raspberry side). This should avoid saturating the raspberry with useless treatment.